### PR TITLE
Build and release with java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         scala-version: [2.13.15]
-        java-version: [8]
+        java-version: [17]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
       - uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:


### PR DESCRIPTION
As [Kafka Server 4.x requires Java 17+](https://kafka.apache.org/40/documentation/compatibility.html), we should do the same.