### PR TITLE
Fix race condition

### DIFF
--- a/kafka-4.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
+++ b/kafka-4.0.x/src/main/scala/monix/kafka/KafkaProducer.scala
@@ -116,7 +116,8 @@ object KafkaProducer {
                     if (isActive.getAndSet(false)) {
                       connection.pop()
                       if (exception != null)
-                        asyncCb.onError(exception)
+                        if (isCanceled.get()) asyncCb.onSuccess(None)
+                        else asyncCb.onError(exception)
                       else
                         asyncCb.onSuccess(Option(meta))
                     } else if (exception != null) {


### PR DESCRIPTION
Applying this PR will fix a race condition in KafkaProducer.send (lines 104–126 of `KafkaProducer.scala`):
1. A send call checks isCanceled.get() → false, so it proceeds
2. close() concurrently sets isCanceled = true and calls producerRef.close()
3. The send call then calls producerRef.send(record, callback) — the message gets queued in Kafka's internal buffer
4. Kafka's close() flushes/cancels pending sends; the KafkaCallback.onCompletion is called with a non-IllegalStateException error
5. This error propagates via asyncCb.onError(exception) (line 119), causing Task.parSequence to fail
The catch block on line 136 handles the case where producerRef.send() throws IllegalStateException synchronously, converting it to None. But it doesn't handle the async case where the send is enqueued first, then fails through the callback after close — which gets re-raised as an error rather than None.

This bug is sometimes caught in the "publish to closed producer when subscribed to topics list" test.