### PR TITLE
Remove isAcked val

### DIFF
--- a/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
+++ b/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservable.scala
@@ -39,8 +39,6 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   protected def config: KafkaConsumerConfig
   protected def consumerT: Task[Consumer[K, V]]
 
-  @volatile
-  protected var isAcked = true
 
   /** Creates a task that polls the source, then feeds the downstream subscriber, returning the resulting
     * acknowledgement
@@ -100,7 +98,6 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
   private def pollHeartbeat(consumer: Consumer[K, V])(implicit scheduler: Scheduler): Task[Unit] = {
     Task.sleep(config.pollHeartbeatRate) >>
       Task.eval {
-        if (!isAcked) {
           consumer.synchronized {
             // needed in order to ensure that the consumer assignment
             // is paused, meaning that no messages will get lost.
@@ -112,7 +109,6 @@ trait KafkaConsumerObservable[K, V, Out] extends Observable[Out] {
               throw new IllegalStateException(errorMsg)
             }
           }
-        }
       }.onErrorHandleWith { ex =>
         Task.now(scheduler.reportFailure(ex)) >>
           Task.sleep(1.seconds)

--- a/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
+++ b/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableAutoCommit.scala
@@ -77,7 +77,6 @@ final class KafkaConsumerObservableAutoCommit[K, V] private[kafka] (
                 if (shouldCommitBefore) consumerCommit(consumer)
                 // Feeding the observer happens on the Subscriber's scheduler
                 // if any asynchronous boundaries happen
-                isAcked = false
                 Observer.feed(out, next.asScala)(out.scheduler)
               }
             }
@@ -88,7 +87,6 @@ final class KafkaConsumerObservableAutoCommit[K, V] private[kafka] (
 
         ackFuture.syncOnComplete {
           case Success(ack) =>
-            isAcked = true
             // The `streamError` flag protects against contract violations
             // (i.e. onSuccess/onError should happen only once).
             // Not really required, but we don't want to depend on the
@@ -113,7 +111,6 @@ final class KafkaConsumerObservableAutoCommit[K, V] private[kafka] (
             }
 
           case Failure(ex) =>
-            isAcked = true
             asyncCb.onError(ex)
         }
       }

--- a/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
+++ b/kafka-4.0.x/src/main/scala/monix/kafka/KafkaConsumerObservableManualCommit.scala
@@ -101,7 +101,6 @@ final class KafkaConsumerObservableManualCommit[K, V] private[kafka] (
                 }
                 // Feeding the observer happens on the Subscriber's scheduler
                 // if any asynchronous boundaries happen
-                isAcked = false
                 Observer.feed(out, result)(out.scheduler)
               }
             catch {
@@ -113,7 +112,6 @@ final class KafkaConsumerObservableManualCommit[K, V] private[kafka] (
 
         ackFuture.syncOnComplete {
           case Success(ack) =>
-            isAcked = true
             // The `streamError` flag protects against contract violations
             // (i.e. onSuccess/onError should happen only once).
             // Not really required, but we don't want to depend on the
@@ -136,7 +134,6 @@ final class KafkaConsumerObservableManualCommit[K, V] private[kafka] (
             }
 
           case Failure(ex) =>
-            isAcked = true
             asyncCb.onError(ex)
         }
       }


### PR DESCRIPTION
The `pollHeartbeat` loop previously skipped calling `consumer.poll()` whenever `isAcked = true`. This created a gap: after the slow downstream (the 2-second sleep) finished and signalled `Continue`, `isAcked` flipped to true and heartbeat polling stopped — but `ackTask` hadn't yet started its next `consumer.poll()` call. Under scheduler load, that gap could exceed `maxPollInterval = 200ms`, causing Kafka to trigger a rebalance.
By removing the `if (!isAcked)` guard, `pollHeartbeat` calls `consumer.poll(Duration.ZERO)` on every tick regardless, closing that gap. It's safe to do unconditionally because:
- The assignment is always paused before `poll(Duration.ZERO)`, so Kafka returns no records
- `consumer.synchronized` ensures it never interleaves with `ackTask`'s own `resume → poll → pause` cycle

This bug was sometimes caught in the "auto committable consumer with slow processing doesn't cause rebalancing" test.